### PR TITLE
Add buildpack_key to cc staging response

### DIFF
--- a/models/staging_messages.go
+++ b/models/staging_messages.go
@@ -24,11 +24,13 @@ type EnvironmentVariable struct {
 }
 
 type StagingInfo struct {
+	BuildpackKey      string `yaml:"-" json:"buildpack_key,omitempty"`
 	DetectedBuildpack string `yaml:"detected_buildpack" json:"detected_buildpack"`
 	StartCommand      string `yaml:"start_command" json:"-"`
 }
 
 type StagingResponseForCC struct {
+	BuildpackKey      string `json:"buildpack_key,omitempty"`
 	DetectedBuildpack string `json:"detected_buildpack,omitempty"`
 	Error             string `json:"error,omitempty"`
 }

--- a/models/staging_messages_test.go
+++ b/models/staging_messages_test.go
@@ -73,17 +73,19 @@ var _ = Describe("StagingMessages", func() {
 	Describe("StagingInfo", func() {
 		Context("when json", func() {
 			stagingJSON := `{
-            "detected_buildpack": "ocaml-buildpack",
-            "start_command": "ocaml-my-camel"
-          }`
+				"buildpack_key": "buildpack-key",
+				"detected_buildpack": "ocaml-buildpack",
+				"start_command": "ocaml-my-camel"
+			}`
 
-			It("exposes an extracted `detected_buildpack` property", func() {
+			It("does not extract the `start_command` property", func() {
 				var stagingInfo StagingInfo
 
 				err := json.Unmarshal([]byte(stagingJSON), &stagingInfo)
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(stagingInfo).Should(Equal(StagingInfo{
+					BuildpackKey:      "buildpack-key",
 					DetectedBuildpack: "ocaml-buildpack",
 				}))
 			})
@@ -116,6 +118,24 @@ start_command: yaml-ize -d`
 				}
 
 				Ω(json.Marshal(stagingResponseForCC)).Should(MatchJSON(`{"detected_buildpack": "ocaml-buildpack"}`))
+			})
+		})
+
+		Context("with an admin buildpack key", func() {
+			It("generates valid JSON with the buildpack key", func() {
+				stagingResponseForCC := StagingResponseForCC{
+					BuildpackKey: "admin-buildpack-key",
+				}
+
+				Ω(json.Marshal(stagingResponseForCC)).Should(MatchJSON(`{"buildpack_key": "admin-buildpack-key"}`))
+			})
+		})
+
+		Context("without an admin buildpack key", func() {
+			It("generates valid JSON and omits the buildpack key", func() {
+				stagingResponseForCC := StagingResponseForCC{}
+
+				Ω(json.Marshal(stagingResponseForCC)).Should(MatchJSON(`{}`))
 			})
 		})
 


### PR DESCRIPTION
Collect the key of the admin buildpack used for staging so it can be sent back to the CC via the staging response.  The goal is to use this information[1] in app usage events once the resolution to story #69196650 is implemented.

[1] https://github.com/cloudfoundry/cloud_controller_ng/blob/4b9fca3aa9782b61515c7993475b21d1e9650ade/lib/cloud_controller/app_stager_task.rb#L27
