### PR TITLE
fix convertVolumeMounts method in buildpack_recipe_builder

### DIFF
--- a/cc_messages/desired_messages.go
+++ b/cc_messages/desired_messages.go
@@ -58,11 +58,16 @@ type CCRouteInfo map[string]*json.RawMessage
 type CCHTTPRoutes []CCHTTPRoute
 
 type VolumeMount struct {
-	Driver       string            `json:"driver"`
-	ContainerDir string            `json:"container_dir"`
-	Mode         string            `json:"mode"`
-	DeviceType   string            `json:"device_type"`
-	Device       map[string]string `json:"device"`
+	Driver       string       `json:"driver"`
+	ContainerDir string       `json:"container_dir"`
+	Mode         string       `json:"mode"`
+	DeviceType   string       `json:"device_type"`
+	Device       SharedDevice `json:"device"`
+}
+
+type SharedDevice struct {
+	VolumeId    string                 `json:"volume_id"`
+	MountConfig map[string]interface{} `json:"mount_config,omitempty"`
 }
 
 func (r CCHTTPRoutes) CCRouteInfo() (CCRouteInfo, error) {


### PR DESCRIPTION
 to expect mount_config as an object (not a string)

[#119780891](https://www.pivotaltracker.com/story/show/119780891)

This is a companion pull request to [this NSYNC pull request](https://github.com/cloudfoundry/nsync/pull/11)