### PR TITLE
Add IsolationSegment to staging/desired messages

### DIFF
--- a/cc_messages/desired_messages.go
+++ b/cc_messages/desired_messages.go
@@ -51,6 +51,7 @@ type DesireAppRequestFromCC struct {
 	LogSource                   string                        `json:"log_source,omitempty"`
 	Network                     *models.Network               `json:"network,omitempty"`
 	VolumeMounts                []*VolumeMount                `json:"volume_mounts"`
+	IsolationSegment            string                        `json:"isolation_segment"`
 }
 
 type CCRouteInfo map[string]*json.RawMessage
@@ -156,6 +157,7 @@ type TaskRequestFromCC struct {
 	Command               string                        `json:"command"`
 	LogSource             string                        `json:"log_source,omit_empty"`
 	VolumeMounts          []*VolumeMount                `json:"volume_mounts"`
+	IsolationSegment      string                        `json:"isolation_segment"`
 }
 
 type TaskFailResponseForCC struct {

--- a/cc_messages/staging_messages.go
+++ b/cc_messages/staging_messages.go
@@ -35,6 +35,7 @@ type StagingRequestFromCC struct {
 	Lifecycle          string                        `json:"lifecycle"`
 	LifecycleData      *json.RawMessage              `json:"lifecycle_data,omitempty"`
 	CompletionCallback string                        `json:"completion_callback"`
+	IsolationSegment   string                        `json:"isolation_segment"`
 }
 
 type BuildpackStagingData struct {


### PR DESCRIPTION
Signed-off-by: Dan Lavine <dlavine@us.ibm.com>

This enables the Isolation Segment work to proceed by adding the IS name/label to the required messages.