### PR TITLE
Struct for sending app evacuation events to CC

### DIFF
--- a/cc_messages/app_rescheduling.go
+++ b/cc_messages/app_rescheduling.go
@@ -1,0 +1,8 @@
+package cc_messages
+
+type AppReschedulingRequest struct {
+	Instance string `json:"instance"`
+	Index    int    `json:"index"`
+	CellID   string `json:"cell_id"`
+	Reason   string `json:"reason,omitempty"`
+}


### PR DESCRIPTION
This PR adds a Go struct to be used to talk to a new internal Cloud Controller endpoint. This goes alongside https://github.com/cloudfoundry/cloud_controller_ng/pull/2447.